### PR TITLE
Add g:star_start_next_match to preserve Vim's default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,15 @@ nmap <silent> g# <Plug>(star-g#)
 
 ## About cursor positon
 
-Vim's original behavior of `*` will make the cursor jump to the **next** match's beginning.  
-This plugin will make the cursor jump to the **current** match's beginning by default.
+Vim's original behavior of `*` will make the cursor jump to the **next**
+match's beginning.  This plugin will make the cursor jump to the **current**
+match's beginning by default.  If you prefer to keep the default behavior, 
+you can
+
+```vim
+" Jump to the next match when use * to search
+let g:star_start_next_match = 1
+```
 
 Some people prefer keeping the cursor positon unchanged when using `*`.  
 But in this case, I need to press 'N' twice to jump to the previous match

--- a/autoload/star.vim
+++ b/autoload/star.vim
@@ -64,6 +64,8 @@ function star#Command(is_visual, is_forward, is_g) abort
 
     if v:count
         let l:postcmd = v:count . (a:is_forward ? '/' : '?') . "\<CR>"
+    elseif g:star_start_next_match
+        let l:postcmd = (a:is_forward ? '/' : '?') . "\<CR>"
     else
         let l:setpos = g:star_keep_cursor_pos
                     \ ? ":noautocmd call setpos('.', ". string(getcurpos()) .")\<CR>"

--- a/plugin/star.vim
+++ b/plugin/star.vim
@@ -15,6 +15,7 @@ let g:loaded_star = 1
 
 let g:star_echo_search_pattern = get(g:, 'star_echo_search_pattern', 1)
 let g:star_keep_cursor_pos = get(g:, 'star_keep_cursor_pos', 0)
+let g:star_start_next_match = get(g:, 'star_start_next_match', 0)
 
 vnoremap <expr><silent> <Plug>(star-*) star#Command(1, 1, 0)
 vnoremap <expr><silent> <Plug>(star-#) star#Command(1, 0, 0)


### PR DESCRIPTION
Thanks for writing and publishing vim-star. I like a lot of its features (like visual mode `*`), but Vim's default behavior of `*` jumping to the _next_ match is too ingrained for me to switch away from.

So I implemented an option `g:star_start_next_match` to reinstate Vim's default behavior here.